### PR TITLE
improve documentation and testing, yet again

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
 	"name": "@oazmi/kitchensink",
-	"version": "0.8.6",
+	"version": "0.9.0",
 	"description": "a collection of personal utility functions",
 	"author": "Omar Azmi",
 	"license": "Lulz plz don't steal yet",
@@ -19,6 +19,7 @@
 	"exports": {
 		".": "./src/mod.ts",
 		"./alias": "./src/alias.ts",
+		"./array1d": "./src/array2d.ts",
 		"./array2d": "./src/array2d.ts",
 		"./binder": "./src/binder.ts",
 		"./browser": "./src/browser.ts",
@@ -65,7 +66,8 @@
 		"proseWrap": "preserve",
 		"include": [
 			"./src/",
-			"./*.md"
+			"./*.md",
+			"./*.json"
 		]
 	},
 	"compilerOptions": {
@@ -121,10 +123,10 @@
 		"dir": "./docs/",
 		"log": "verbose",
 		"copy": [
-			[
-				"./examples/",
-				"./examples/"
-			]
+			["./readme.md", "./readme.md"],
+			["./license.md", "./license.md"],
+			["./src/", "./src/"],
+			["./examples/", "./examples/"]
 		]
 	},
 	"buildNpm": {

--- a/src/alias.ts
+++ b/src/alias.ts
@@ -416,7 +416,7 @@ export const promise_race = /*@__PURE__*/ promise_constructor.race.bind(promise_
 export const promise_reject = /*@__PURE__*/ promise_constructor.reject.bind(promise_constructor)
 /** alias for `Promise.resolve`. */
 export const promise_resolve = /*@__PURE__*/ promise_constructor.resolve.bind(promise_constructor)
-/** alias for `Promise.withResolvers`. <br>
+/** alias for `Promise.withResolvers`.
  * create a promise with external resolver and rejecter functions, provided in an object form.
  * 
  * if you'd like a more minifiable version, consider using the array equivalent: {@link promise_outside}.
@@ -531,7 +531,7 @@ export const console_warn = /*@__PURE__*/ (() => console_object.warn)() as Conso
 
 // `performance` aliases
 
-/** get the current high-precision time in milliseconds. <br> alias for `performance.now`. */
+/** get the current high-precision time in milliseconds. alias for `performance.now`. */
 export const performance_now = /*@__PURE__*/ performance_object.now.bind(performance_object)
 
 // built-in `window` function aliases

--- a/src/array2d.ts
+++ b/src/array2d.ts
@@ -6,7 +6,6 @@
  * @module
 */
 
-import { array_isEmpty, math_random } from "./alias.ts"
 import { max, modulo } from "./numericmethods.ts"
 import { isFunction } from "./struct.ts"
 
@@ -363,81 +362,4 @@ export const meshMap = <X, Y, Z>(map_fn: (x: X, y: Y) => Z, x_values: Array<X>, 
 		z_values[x_idx] = row
 	}
 	return z_values
-}
-
-/** shuffle a 1D array via mutation. the ordering of elements will be randomized by the end.
- * 
- * ```ts
- * import { assertEquals, assertNotEquals } from "jsr:@std/assert"
- * 
- * const
- * 	range_100 = Array(100).fill(0).map((_, i) => (i)), // sequntially numbered array
- * 	my_arr = range_100.slice()
- * shuffleArray(my_arr) // shuffling our array via mutation
- * 
- * // the shuffled array is very unlikely to equal to the original unshuffled form 
- * assertNotEquals(my_arr, range_100)
- * // sort the shuffled array to assert the preservation of the contained items
- * assertEquals(my_arr.toSorted((a, b) => (a - b)), range_100)
- * ```
-*/
-export const shuffleArray = <T>(arr: Array<T>): Array<T> => {
-	const
-		len = arr.length,
-		rand_int = () => (math_random() * len) | 0,
-		swap = (i1: number, i2: number) => {
-			const temp = arr[i1]
-			arr[i1] = arr[i2]
-			arr[i2] = temp
-		}
-	for (let i = 0; i < len; i++) { swap(i, rand_int()) }
-	return arr
-}
-
-/** a generator that shuffles your 1D array via mutation, then yields randomly selected non-repeating elements out of it, one by one,
- * until all elements have been yielded, at which a new cycle begins, and the items in the array are re-shuffled again.
- * i.e. after every new cycle, the ordering of the randomly yielded elements will differ from the ordering of the previous cycle.
- * 
- * moreover, you can call the iterator with an optional number argument that specifies if you wish to skip ahead or go back a certain number of elements.
- * - `1`: go to next element (default behavior)
- * - `0`: receive the same element as before
- * - `-1`: go to previous next element
- * - `+ve number`: skip to next `number` of elements
- * - `-ve number`: go back `number` of elements
- * 
- * note that once a cycle is complete, going back won't restore the correct element from the previous cycle, because the info about the previous cycle gets lost.
- * 
- * ```ts
- * import { assert, assertEquals, assertNotEquals } from "jsr:@std/assert"
- * 
- * const
- * 	my_playlist = ["song1", "song2", "song3", "song4"],
- * 	my_queue = my_playlist.slice(),
- * 	track_iter = shuffledDeque(my_queue) // shuffles our play queue via mutation, and then indefinitely provides unique items each cycle
- * 
- * const
- * 	track1 = track_iter.next().value,
- * 	track2 = track_iter.next(1).value,
- * 	track3 = track_iter.next().value
- * 
- * assertEquals(track1, track_iter.next(-2).value)
- * assertEquals(track2, track_iter.next(1).value)
- * assertEquals(track3, track_iter.next().value)
- * 
- * const track4 = track_iter.next().value // final track of the current queue
- * const track5 = track_iter.next().value // the queue has been reset, and re-shuffled
- * 
- * assert([track1, track2, track3].includes(track4) === false)
- * assert([track1, track2, track3, track4].includes(track5) === true)
- * ```
-*/
-export const shuffledDeque = function* <T>(arr: Array<T>): Generator<T, void, number | undefined> {
-	let i = arr.length // this is only temporary. `i` immediately becomes `0` when the while loop begins
-	while (!array_isEmpty(arr)) {
-		if (i >= arr.length) {
-			i = 0
-			shuffleArray(arr)
-		}
-		i = max(i + ((yield arr[i]) ?? 1), 0)
-	}
 }

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -111,7 +111,7 @@
  * @module
 */
 
-import { prototypeOfClass } from "./struct.ts"
+import type { ConstructorOf, PrototypeOf } from "./typedefs.ts"
 
 
 export type BindableFunction<T, A extends any[], B extends any[], R> = ((this: T, ...args: [...A, ...B]) => R)
@@ -291,6 +291,10 @@ export const bindMethodToSelfByName = /*@__PURE__*/ <
 ) => self[method_name].bind<S, A, S[M] extends BindableFunction<S, A, infer B, R> ? B : never, R>(self, ...args)
 
 const
+	// NOTE: the `prototypeOfClass` over here is a clone of the one in `"./srtruct.ts"`, but I want this file to be dependency free, hence is why I have to clone it.
+	prototypeOfClass = <T, Args extends any[] = any[]>(cls: ConstructorOf<T, Args>): PrototypeOf<typeof cls> => {
+		return cls.prototype
+	},
 	array_proto = /*@__PURE__*/ prototypeOfClass(Array),
 	map_proto = /*@__PURE__*/ prototypeOfClass(Map),
 	set_proto = /*@__PURE__*/ prototypeOfClass(Set),

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -1,5 +1,6 @@
-/** utility functions for creating other general purpose functions that can bind their passed function's functionality to some specific object. <br>
- * those are certainly a lot of words thrown in the air with no clarity as to what am I even saying. <br>
+/** utility functions for creating other general purpose functions that can bind their passed function's functionality to some specific object.
+ * 
+ * those are certainly a lot of words thrown in the air with no clarity as to what am I even saying.
  * just as they say, a code block example is worth a thousand assembly instructions. here's the gist of it:
  * 
  * ```ts
@@ -104,9 +105,9 @@
  * - finally, property accesses are not easily minifiable (although they do get compressed when gzipped).
  *   however, if you bind your method calls to a variable, then it will become minifiable, which is somewhat the primary motivation for this submodule.
  * 
- * with full automatic typing, you won't be compensating in any way. <br>
- * on the side note, it was figuring out the automatic typing that took me almost 16 hours just to write 3 lines of equivalent javascript code for the main 2 factory functions of this submodule. <br>
- * curse you typescript!
+ * with full automatic typing, you won't be compensating in any way.
+ * on the side note, it was figuring out the automatic typing that took me almost 16 hours just to write 3 lines of equivalent javascript code for the main 2 factory functions of this submodule.
+ * **curse you typescript!**
  * 
  * @module
 */

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -8,9 +8,10 @@ import { bind_string_charCodeAt } from "./binder.ts"
 import { isArray } from "./struct.ts"
 import type { TypeName } from "./typedefs.ts"
 
-/** create a blob out of your `Uint8Array` bytes buffer and queue it for downloading. <br>
- * you can also provide an optional `file_name` and `mime_type` <br>
- * technically, you can download any kind of data, so long as your `mime_type` and `data` pair match within the capabilities of your the browser's internal blob encoder <br>
+/** create a blob out of your `Uint8Array` bytes buffer and queue it for downloading.
+ * 
+ * you can also provide an optional `file_name` and `mime_type`.
+ * technically, you can download any kind of data, so long as your `mime_type` and `data` pair match within the capabilities of your the browser's internal blob encoder.
 */
 export const downloadBuffer = (data: Uint8Array | string | any, file_name: string = "data.bin", mime_type: string = "application/octet-stream") => {
 	const
@@ -23,10 +24,13 @@ export const downloadBuffer = (data: Uint8Array | string | any, file_name: strin
 	anchor.remove() // removethe un-needed node
 }
 
-/** convert a blob to base64 string, with the data header included. <br>
- * use {@link blobToBase64Split} to get a 2-tuple with the data header split from the data body <br>
- * or use {@link blobToBase64Body} to get just the body of the data <br>
- * this function works correctly all the time, unlike `btoa`, which fails for arbitrary bytes
+/** convert a blob to base64 string, with the data header included.
+ * 
+ * this function works correctly all the time, unlike `btoa`, which fails for arbitrary bytes.
+ * 
+ * other related functions that you may find useful:
+ * - use {@link blobToBase64Split} to get a 2-tuple with the data header split from the data body.
+ * - or use {@link blobToBase64Body} to get just the body of the data.
 */
 export const blobToBase64 = (blob: Blob): Promise<string> => {
 	const reader = new FileReader()
@@ -37,13 +41,13 @@ export const blobToBase64 = (blob: Blob): Promise<string> => {
 	})
 }
 
-/** convert a blob to base64 string with the header and body separated as a 2-tuple. <br> */
+/** convert a blob to base64 string with the header and body separated as a 2-tuple. */
 export const blobToBase64Split = (blob: Blob): Promise<[string, string]> => blobToBase64(blob).then((str_b64: string) => {
 	const [head, body] = str_b64.split(";base64,", 2) as [string, string]
 	return [head + ";base64,", body]
 })
 
-/** convert a blob to base64 string with the header omitted. <br> */
+/** convert a blob to base64 string with the header omitted. */
 export const blobToBase64Body = (blob: Blob): Promise<string> => blobToBase64Split(blob).then((b64_tuple: [string, string]) => b64_tuple[1])
 
 /** convert a base64 encoded string (no header) into a `Uint8Array` bytes containing the binary data

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -747,7 +747,7 @@ export class Deque<T> {
 	}
 }
 
-/** invert a map */
+/** invert a `Map<F, Set<R>>` to `Map<R, Set<F>>`. */
 export const invertMap = <F, R>(forward_map: Map<F, Set<R>>): Map<R, Set<F>> => {
 	const reverse_map_keys: R[] = []
 	forward_map.forEach((rset) => { reverse_map_keys.push(...rset) })
@@ -765,6 +765,8 @@ export const invertMap = <F, R>(forward_map: Map<F, Set<R>>): Map<R, Set<F>> => 
 	}
 	return reverse_map
 }
+
+// TODO: from this line onwards, the doc comments, doc tests, and conciseness have yet to be reviewed again.
 
 export type InvertibleMapBase<K, V> = Map<K, Set<V>> & Omit<PrefixProps<Map<V, Set<K>>, "r">, "rclear" | "rset"> & { rset: (key: V, value: Iterable<K>) => InvertibleMapBase<K, V> }
 
@@ -1388,6 +1390,8 @@ export const HybridTree = /*@__PURE__*/ treeClass_Factory(HybridWeakMap)
 
 
 export class StackSet<T> extends Array<T> {
+	static override[Symbol.species] = Array
+
 	$set = new Set<T>()
 	$add = bind_set_add(this.$set)
 	$del = bind_set_delete(this.$set)
@@ -1511,6 +1515,8 @@ export class StackSet<T> extends Array<T> {
  * when the capacity hits the maximum length, then it is reduced down to the minimum capacity.
 */
 export class LimitedStack<T> extends Array<T> {
+	static override[Symbol.species] = Array
+
 	/** minimum capacity of the stack. <br>
 	 * when the stack size hits the maximum capacity {@link max}, the oldest items (at the
 	 * bottom of the stack) are discarded so that the size goes down to the minimum specified here
@@ -1625,7 +1631,7 @@ export interface ChainedPromiseQueueConfig<T> {
  * - see if `Symbol.asyncIterator` can be used for iterating over the current list of task/job bundles asynchronously
  * 
  * @example
- * ```ts ignore
+ * ```ts
  * const promise_queue = new ChainedPromiseQueue([
  * 	[(value: string) => value.toUpperCase()],
  * 	[(value: string) => "Result: " + value],
@@ -1651,6 +1657,8 @@ export interface ChainedPromiseQueueConfig<T> {
  * ```
 */
 export class ChainedPromiseQueue<T> extends Array<Promise<T>> {
+	static override[Symbol.species] = Array
+
 	/** the chain of the "then" functions to run each newly pushed promise through. <br>
 	 * you may dynamically modify this sequence so that all newly pushed promises will have to go through a different set of "then" functions. <br>
 	 * do note that old (already existing) promises will not be affected by the modified chain of "then" functions.
@@ -1673,7 +1681,7 @@ export class ChainedPromiseQueue<T> extends Array<Promise<T>> {
 	 * and its originating `Promise` which was pushed  into `this` collection will also get removed. <br>
 	 * (the removal is done by the private {@link del} method)
 	 * 
-	 * ```ts ignore
+	 * ```ts
 	 * const do_actions = new ChainedPromiseQueue<string>([
 	 * 	[(value: string) => value.toUpperCase()],
 	 * 	[(value: string) => "Result: " + value],

--- a/src/devdebug.ts
+++ b/src/devdebug.ts
@@ -1,6 +1,7 @@
-/** utility functions for development debugging. <br>
- * all development debug functions are assigned to global scope upon any import; <br>
- * because it's easier to access it that way, and also makes it accessible through the console.
+/** utility functions for development debugging.
+ * 
+ * all development debug functions are assigned to global scope upon any import.
+ * this is because it is easier to access it that way, and also makes it accessible through the console.
  * 
  * nothing here is re-exported by {@link "mod"}. you will have to import this file directly to use any alias.
  * 
@@ -45,8 +46,10 @@ export interface DebugWindowCanvasControls {
 	pause: () => void
 }
 
-/** preview the offscreen canvas obtainable via {@link getBgCanvas}, on a separate popup debug window <br>
- * alternatively, you can provide your own canvas source to preview on a separate popup debug window
+/** preview the offscreen canvas obtainable via {@link getBgCanvas}, on a separate popup debug window.
+ * 
+ * alternatively, you can provide your own canvas source to preview on a separate popup debug window.
+ * 
  * @param source_canvas a canvas source. defaults to {@link getBgCanvas} from the {@link image} module if none is provided
  * @param fps number of times the popup canvas will be updated in a second
  * @returns a popup window object with the ability to control the canvas through the {@link DebugWindowCanvasControls} interface

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -11,6 +11,7 @@
 */
 
 // export * from "./alias.ts"
+export * from "./array1d.ts"
 export * from "./array2d.ts"
 // export * from "./binder.ts"
 export * from "./browser.ts"

--- a/src/numericmethods.ts
+++ b/src/numericmethods.ts
@@ -1,4 +1,5 @@
-/** utility functions for common number manipulation functions <br>
+/** utility functions for common number manipulation functions.
+ * 
  * these functions go nicely with the {@link "mapper"} and {@link "lambdacalc"} submodules.
  * 
  * @module
@@ -8,11 +9,22 @@ import { number_MAX_VALUE } from "./alias.ts"
 import type { UnitInterval } from "./typedefs.ts"
 
 
-/** clamp a `number` to inclusive `min` and `max` intervals. <br>
+/** clamp a `number` to inclusive `min` and `max` intervals.
+ * 
  * you can also provide a type alias for the output interval `OutInterval` number through the use of the generic parameter.
+ * 
  * @param value value to clamp
  * @param min inclusive minimum of the interval
  * @param max inclusive maximum of the interval
+ * 
+ * @example
+ * ```ts
+ * import { assertEquals } from "jsr:@std/assert"
+ * 
+ * assertEquals(clamp(-5, -1, 10), -1)
+ * assertEquals(clamp(5, -1, 10),  5)
+ * assertEquals(clamp(15, -1, 10), 10)
+ * ```
 */
 export const clamp = <
 	OutInterval extends number = number
@@ -22,75 +34,174 @@ export const clamp = <
 	max: OutInterval = number_MAX_VALUE as OutInterval,
 ): OutInterval => (value < min ? min : value > max ? max : value) as OutInterval
 
-/** get the mathematical modulo: `value` **mod** `mod`. <br>
- * **modulo** is different from javascript's `%` **remainder** operator in that which the **modulo** operation always returns a positive number <br>
+/** get the mathematical modulo: `value` **mod** `mod`.
+ * 
+ * **modulo** is different from javascript's `%` **remainder** operator in that the **modulo** operation always returns a positive number.
+ * 
+ * @example
+ * ```ts
+ * import { assertEquals } from "jsr:@std/assert"
+ * 
+ * assertEquals(modulo( 5, 3), 2)
+ * assertEquals(modulo(-5, 3), 1)
+ * assertEquals(modulo(-4, 3), 2)
+ * assertEquals(modulo(-3, 3), 0)
+ * assertEquals( 5 % 3,  2)
+ * assertEquals(-5 % 3, -2)
+ * assertEquals(-4 % 3, -1)
+ * assertEquals(-3 % 3, -0)
+ * ```
 */
-export const modulo = (value: number, mod: number) => ((value % mod) + mod) % mod
+export const modulo = (value: number, mod: number) => (((value % mod) + mod) % mod)
 
-/** get the linearly interpolated value between two scalar points `x0` and `x1`, decided by unit interval time `t`. <br>
- * ie: `lerp(x0, x1, 0.0) === x0`, and `lerp(x0, x1, 1.0) === x1`, and `x0 < lerp(x0, x1, t > 0.0 && t < 1.0) < x1`. <br>
- * note that lerp does not clamp the time to the closed {@link UnitInterval} `[0.0, 1.0]`. <br>
- * use {@link lerpClamped} if you would like to clamp the time.
+/** get the linearly interpolated value between two scalar points `x0` and `x1`, decided by unit interval time `t`.
+ * 
+ * in other words:
+ * - `lerp(x0, x1, 0.0) === x0`
+ * - `lerp(x0, x1, 1.0) === x1`
+ * - `x0 < lerp(x0, x1, t > 0.0 && t < 1.0) < x1`
+ * 
+ * > [!note]
+ * > this lerp function does not clamp the time parameter `t` to the closed {@link UnitInterval} `[0.0, 1.0]`.
+ * > to ensure clamping of `t` to the unit interval, use the {@link lerpClamped} function.
+ * 
+ * @example
+ * ```ts
+ * import { assertEquals } from "jsr:@std/assert"
+ * 
+ * assertEquals(lerp( 0, 100,  0.5),  50)
+ * assertEquals(lerp(50, 100,  0.5),  75)
+ * assertEquals(lerp(50, 100,  0.0),  50)
+ * assertEquals(lerp(50, 100,  1.0), 100)
+ * assertEquals(lerp(50, 100,  1.5), 125)
+ * assertEquals(lerp(50, 100, -0.5),  25)
+ * assertEquals(lerp(50, 100, -1.0),   0)
+ * assertEquals(lerp(50, 100, -2.5), -75)
+ * ```
 */
-export const lerp = (x0: number, x1: number, t: UnitInterval) => t * (x1 - x0) + x0
+export const lerp = (x0: number, x1: number, t: UnitInterval) => (t * (x1 - x0) + x0)
 
-/** same as {@link lerp}, except the time `t` is Clamped to the closed {@link UnitInterval} `[0.0, 1.0]` */
-export const lerpClamped = (x0: number, x1: number, t: UnitInterval) => (t < 0 ? 0 : t > 1 ? 1 : t) * (x1 - x0) + x0
+/** same as {@link lerp}, except the time `t` is Clamped to the closed {@link UnitInterval} `[0.0, 1.0]`. */
+export const lerpClamped = (x0: number, x1: number, t: UnitInterval) => ((t < 0 ? 0 : t > 1 ? 1 : t) * (x1 - x0) + x0)
 
-/** get the {@link lerp} of the `i`th dimension of two vector points `v0` and `v1`, at time `t`. */
-export const lerpi = <Vec extends number[] = number[]>(v0: Vec, v1: Vec, t: UnitInterval, i: number): number => t * (v1[i] - v0[i]) + v0[i]
+/** get the {@link lerp} interpolation of the `i`th dimension of two array vector points `v0` and `v1`, at time `t`.
+ * 
+ * @example
+ * ```ts
+ * import { assertEquals } from "jsr:@std/assert"
+ * 
+ * assertEquals(lerpi([ 0, 40], [100, 80],  0.5, 0),  50)
+ * assertEquals(lerpi([ 0, 40], [100, 80],  0.5, 1),  60)
+ * assertEquals(lerpi([50, 40], [100, 80],  0.5, 0),  75)
+ * assertEquals(lerpi([50, 40], [100, 80],  0.0, 0),  50)
+ * assertEquals(lerpi([50, 40], [100, 80],  1.0, 0), 100)
+ * assertEquals(lerpi([50, 40], [100, 80],  1.5, 0), 125)
+ * assertEquals(lerpi([50, 40], [100, 80], -0.5, 0),  25)
+ * assertEquals(lerpi([50, 40], [100, 80], -1.0, 0),   0)
+ * assertEquals(lerpi([50, 40], [100, 80], -2.5, 0), -75)
+ * ```
+*/
+export const lerpi = <Vec extends number[] = number[]>(v0: Vec, v1: Vec, t: UnitInterval, i: number): number => (t * (v1[i] - v0[i]) + v0[i])
 
-/** get the {@link lerpClamped} of the `i`th dimension of two vector points `v0` and `v1`, at time `t`. */
+/** get the {@link lerpClamped} interpolation of the `i`th dimension of two array vector points `v0` and `v1`, at time `t`. */
 export const lerpiClamped = <Vec extends number[] = number[]>(v0: Vec, v1: Vec, t: UnitInterval, i: number): number => (t < 0 ? 0 : t > 1 ? 1 : t) * (v1[i] - v0[i]) + v0[i]
 
-/** get the {@link lerp} vector between two vector points `v0` and `v1`, at time `t`. */
+/** get the {@link lerp} interpolation vector between two array vector points `v0` and `v1`, at time `t`.
+ * 
+ * @example
+ * ```ts
+ * import { assertEquals } from "jsr:@std/assert"
+ * 
+ * assertEquals(lerpv([ 0, 40], [100, 80],  0.5), [ 50,  60])
+ * assertEquals(lerpv([50,  0], [100, 80],  0.5), [ 75,  40])
+ * assertEquals(lerpv([50, 40], [100, 80],  0.0), [ 50,  40])
+ * assertEquals(lerpv([50, 40], [100, 80],  1.0), [100,  80])
+ * assertEquals(lerpv([50, 40], [100, 80],  1.5), [125, 100])
+ * assertEquals(lerpv([50, 40], [100, 80], -0.5), [ 25,  20])
+ * assertEquals(lerpv([50, 40], [100, 80], -1.0), [  0,   0])
+ * assertEquals(lerpv([50, 40], [100, 80], -2.5), [-75, -60])
+ * assertEquals(lerpv(
+ * 	[   0,  10, 100, 1000],
+ * 	[1000, 100,  10,    0],
+ * 	0.25,
+ * ), [250, 32.5, 77.5, 750])
+ * ```
+*/
 export const lerpv = <Vec extends number[] = number[]>(v0: Vec, v1: Vec, t: UnitInterval): Vec => {
 	const
 		len = v0.length,
 		v: Vec = Array(len).fill(0) as Vec
-	for (let i = 0, len = v0.length; i < len; i++) { v[i] = t * (v1[i] - v0[i]) + v0[i] }
+	for (let i = 0; i < len; i++) { v[i] = t * (v1[i] - v0[i]) + v0[i] }
 	return v
 }
 
-/** get the {@link lerpClamped} vector between two vector points `v0` and `v1`, at time `t`. */
+/** get the {@link lerpClamped} interpolation vector between two array vector points `v0` and `v1`, at time `t`. */
 export const lerpvClamped = <Vec extends number[] = number[]>(v0: Vec, v1: Vec, t: UnitInterval): Vec => lerpv<Vec>(v0, v1, t < 0 ? 0 : t > 1 ? 1 : t)
 
-/** get the inverse of {@link lerp}`(x0, x1, t)`, which is to say: find the {@link UnitInterval} parameter `t`, given a scalar number `x` in the closed interval `[x0, x1]` */
-export const invlerp = (x0: number, x1: number, x: number): UnitInterval => (x - x0) / (x1 - x0)
+/** get the inverse of the interpolation {@link lerp}`(x0, x1, t)`, which is to say:
+ * find the {@link UnitInterval} parameter `t`, given a scalar number `x` in the closed interval `[x0, x1]`.
+ * 
+ * @example
+ * ```ts
+ * import { assertEquals } from "jsr:@std/assert"
+ * 
+ * assertEquals(invlerp( 0, 100,   50),  0.5)
+ * assertEquals(invlerp(50, 100,   75),  0.5)
+ * assertEquals(invlerp(50, 100,   50),  0.0)
+ * assertEquals(invlerp(50, 100,  100),  1.0)
+ * assertEquals(invlerp(50, 100,  125),  1.5)
+ * assertEquals(invlerp(50, 100,   25), -0.5)
+ * assertEquals(invlerp(50, 100,    0), -1.0)
+ * assertEquals(invlerp(50, 100,  -75), -2.5)
+ * ```
+*/
+export const invlerp = (x0: number, x1: number, x: number): UnitInterval => ((x - x0) / (x1 - x0))
 
-/** same as {@link invlerp}, except that we force clamp the output {@link UnitInterval} `t` to the closed interval `[0, 1]` */
+/** same as {@link invlerp}, except that we force clamp the output {@link UnitInterval} `t` to the closed interval `[0, 1]`. */
 export const invlerpClamped = (x0: number, x1: number, x: number): UnitInterval => {
 	const t = (x - x0) / (x1 - x0)
 	return t < 0 ? 0 : t > 1 ? 1 : t
 }
 
-/** get the {@link invlerp} of the `i`th dimension of two vector point intervals `v0` and `v1`, at vector position `v`. */
+/** get the {@link invlerp} (inverse interpolation) of the `i`th dimension of two vector point intervals `v0` and `v1`, at vector position `v`. */
 export const invlerpi = <Vec extends number[] = number[]>(v0: Vec, v1: Vec, v: Vec, i: number): UnitInterval => (v[i] - v0[i]) / (v1[i] - v0[i])
 
-/** get the {@link invlerpClamped} of the `i`th dimension of two vector point intervals `v0` and `v1`, at vector position `v`. */
+/** get the {@link invlerpClamped} of the `i`th dimension of two array vector point intervals `v0` and `v1`, at vector position `v`. */
 export const invlerpiClamped = <Vec extends number[] = number[]>(v0: Vec, v1: Vec, v: Vec, i: number): UnitInterval => {
 	const t = (v[i] - v0[i]) / (v1[i] - v0[i])
 	return t < 0 ? 0 : t > 1 ? 1 : t
 }
 
-/** `limp` is a made up abbreviation for *linear interval map*, which linearly maps
+/** `limp` is a made up abbreviation for _linear interval map_, which linearly maps:
  * - a scalar value `x0`, that's in a
  * - scalar interval `u0: [min: number, max: number]` to
  * - a scalar output return value `x1`, that's in the
  * - scalar interval `u1: [min: number, max: number]`
  * 
- * the math equation is simply `x1 = u1[0] + (x - u0[0]) * (u1[1] - u1[0]) / (u0[1] - u0[0])`. <br>
- * which is basically doing inverse_lerp on `x0` to find `t`, then applying lerp onto interval `u1` with the found `t`
+ * the math equation is simply `x1 = u1[0] + (x - u0[0]) * (u1[1] - u1[0]) / (u0[1] - u0[0])`.
+ * which is basically doing inverse_lerp on `x0` to find `t`, then applying lerp onto interval `u1` with the found `t`.
+ * 
+ * you may think of this function as a means for finding the "y-coordinate" (`x1`) of a point at the "x-coordinate" `x0`,
+ * that is between two connected line segment points `(u0[0], u1[0])` and `(u0[1], u1[1])`.
 */
-export const limp = (u0: [min: number, max: number], u1: [min: number, max: number], x0: number): number => u1[0] + (x0 - u0[0]) * (u1[1] - u1[0]) / (u0[1] - u0[0])
+export const limp = (u0: [min: number, max: number], u1: [min: number, max: number], x0: number): number => (u1[0] + (x0 - u0[0]) * (u1[1] - u1[0]) / (u0[1] - u0[0]))
 
-/** same as {@link limp}, except the output `x1` is force clamped to the interval `u1` */
+/** same as {@link limp}, except the output `x1` is force clamped to the interval `u1`. */
 export const limpClamped = (u0: [min: number, max: number], u1: [min: number, max: number], x0: number): number => {
 	const t = (x0 - u0[0]) / (u0[1] - u0[0])
 	return (t < 0 ? 0 : t > 1 ? 1 : t) * (u1[1] - u1[0]) + u1[0]
 }
 
-/** sum up an array of number */
+/** sum up an array of numbers.
+ * 
+ * @example
+ * ```ts
+ * import { assertEquals } from "jsr:@std/assert"
+ * 
+ * assertEquals(sum([0, 1, 2, 3, 4]),  10)
+ * assertEquals(sum([-11, 7, 5, -8]),  -7)
+ * ```
+*/
 export const sum = (values: number[]): number => {
 	let
 		total = 0,
@@ -99,8 +210,14 @@ export const sum = (values: number[]): number => {
 	return total
 }
 
-/** minimum between two numbers. this is faster than `Math.min` as it uses the ternary conditional operator, which makes it highly JIT optimized. */
+/** get the minimum between two numbers.
+ * 
+ * this function is faster than `Math.min` as it uses the ternary conditional operator, which makes it highly JIT optimized.
+*/
 export const min = (v0: number, v1: number) => (v0 < v1 ? v0 : v1)
 
-/** maximum between two numbers. this is faster than `Math.max` as it uses the ternary conditional operator, which makes it highly JIT optimized. */
+/** get the maximum between two numbers.
+ * 
+ * this function is faster than `Math.max` as it uses the ternary conditional operator, which makes it highly JIT optimized.
+*/
 export const max = (v0: number, v1: number) => (v0 > v1 ? v0 : v1)

--- a/src/pathman.ts
+++ b/src/pathman.ts
@@ -574,10 +574,10 @@ export const trimStartDotSlashes = (str: string): string => {
 /** trim all trivial trailing forward-slashes ("/") and dot-slashes ("./"), at the end a string.
  * but exclude non-trivial dotdotslash ("/../") from being wrongfully trimmed.
  * 
- * TODO: this operation is somewhat expensive, because: <br>
- * the implementation uses regex, however it was not possible for me to design a regex that handles the input string as is,
- * so I resort to reversing the input string, and using a slightly easier-to-design regex that discovers trivial (dot)slashes in reverse order,
- * and then after the string replacement, I reverse it again and return it as the output.
+ * TODO: this operation is somewhat expensive, because:
+ * - the implementation uses regex, however it was not possible for me to design a regex that handles the input string as is,
+ *   so I resort to reversing the input string, and using a slightly easier-to-design regex that discovers trivial (dot)slashes in reverse order,
+ *   and then after the string replacement, I reverse it again and return it as the output.
  * 
  * @example
  * ```ts

--- a/src/stringman.ts
+++ b/src/stringman.ts
@@ -27,27 +27,58 @@ import type { NumericArray, TypedArray } from "./typedefs.ts"
  * ```
 */
 export interface HexStringReprConfig {
-	/** separator character string between bytes. <br> **defaults to** `", "` */
+	/** separator character string between bytes.
+	 * 
+	 * @defaultValue `", "`
+	*/
 	sep: string
-	/** what string to prefix every hex-string byte with? <br> **defaults to** `"0x"` */
+
+	/** what string to prefix every hex-string byte with?
+	 * 
+	 * @defaultValue  `"0x"`
+	*/
 	prefix: string
-	/** what string to add to the end of every hex-string byte? <br> **defaults to** `""` (an empty string) */
+
+	/** what string to add to the end of every hex-string byte?
+	 * 
+	 * @defaultValue `""` (an empty string)
+	*/
 	postfix: string
-	/** do you want to include a trailing {@link sep} after the final byte? <br>
-	 * example output when true: `"[0x01, 0x02, 0x03,]"`, <br>
-	 * example output when false: `"[0x01, 0x02, 0x03]"`. <br>
-	 * **defaults to** `false`
+
+	/** specify if you want to include a trailing {@link sep} after the final byte.
+	 * 
+	 * - example output when `true`: `"[0x01, 0x02, 0x03,]"`,
+	 * - example output when `false`: `"[0x01, 0x02, 0x03]"`.
+	 * 
+	 * @defaultValue `false`
 	*/
 	trailingSep: boolean
-	/** the left bracket string. <br> **defaults to** `"["` */
+
+	/** the left bracket string.
+	 * 
+	 * @defaultValue `"["`
+	*/
 	bra: string
-	/** the right bracket string. <br> **defaults to** `"]"` */
+
+	/** the right bracket string.
+	 * 
+	 * @defaultValue `"]"`
+	*/
 	ket: string
-	/** do we want upper case letters for the hex-string? <br> **defaults to** `true` */
+
+	/** specify if you want upper case letters for the hex-string.
+	 * 
+	 * @defaultValue  `true`
+	*/
 	toUpperCase: boolean
-	/** provide an alternate number base to encode the numbers into. see {@link Number.toString} for more details. <br>
-	 * use `16` for a hex-string, or `2` for binary-string, accepted values must be between `2` and `36` <br>
-	 * **defaults to** `16`
+
+	/** provide an alternate number base to encode the numbers into.
+	 * see {@link Number.toString} for more details.
+	 * 
+	 * use `16` for a hex-string, or `2` for binary-string.
+	 * accepted values must be between `2` and `36`.
+	 * 
+	 * @defaultValue `16`
 	*/
 	radix: number
 }
@@ -455,7 +486,7 @@ export const quote = (str: string): string => ("\"" + str + "\"")
 /** reversing a string is not natively supported by javascript, and performing it is not so trivial when considering that
  * you can have composite UTF-16 characters (such as emojis and characters with accents).
  * 
- * see this excellent solution in stackoverflow for reversing a string: [stackoverflow.com/a/60056845](https://stackoverflow.com/a/60056845). <br>
+ * see this excellent solution in stackoverflow for reversing a string: [stackoverflow.com/a/60056845](https://stackoverflow.com/a/60056845).
  * we use the slightly less reliable technique provided by the answer, as it has a better browser support.
 */
 export const reverseString = (input: string): string => {

--- a/src/typedefs.ts
+++ b/src/typedefs.ts
@@ -38,7 +38,8 @@ export type CallableFunctionsOf<T> = { [K in keyof T as (T[K] extends (CallableF
 /** get all data members (non-methods) of a class-instance */
 export type MembersOf<T> = Omit<T, keyof MethodsOf<T>>
 
-/** map each entry (key-value pair) of an object, to a tuple of the key and its corresponding value. <br>
+/** map each entry (key-value pair) of an object, to a tuple of the key and its corresponding value.
+ * 
  * the output of this type is what the builtin `Object.entries` static method should ideally return if it were typed strictly.
  * 
  * @example
@@ -72,9 +73,13 @@ export type PrefixProps<T, PRE extends string> = { [K in keyof T & string as `${
 /** add a postfix (suffix) `POST` to all property names of object `T` */
 export type PostfixProps<T, POST extends string> = { [K in keyof T & string as `${K}${POST}`]: T[K] }
 
-/** allows one to declare static interface `CONSTRUCTOR` that must be implemented by a class `CLASS` <br>
- * it is important that your `CONSTRUCTOR` static interface must contain a constructor method in it.
- * although, that constructor could be super generalized too, despite the other static methods being narrowly defined, like:
+/** allows one to declare static interface `CONSTRUCTOR` that must be implemented by a class `CLASS`.
+ * 
+ * > [!important]
+ * > your `CONSTRUCTOR` static interface **must** contain a constructor method in it.
+ * > although, that constructor could be super generalized too, despite the other static methods being narrowly defined.
+ * > take the following for instance:
+ * 
  * ```ts
  * // interface for a class that must implement a static `clone` method, which should return a clone of the provided object `obj`, but omit numeric keys
  * interface Cloneable {
@@ -82,6 +87,7 @@ export type PostfixProps<T, POST extends string> = { [K in keyof T & string as `
  * 	clone<T>(obj: T): Omit<T, number>
  * }
  * ```
+ * 
  * to use this utility type, you must provide the static interface as the first parameter,
  * and then `typeof CLASS_NAME` (which is the name of the class itself) as the second parameter.
  * 
@@ -92,19 +98,23 @@ export type PostfixProps<T, POST extends string> = { [K in keyof T & string as `
  * 	pop(): T | undefined
  * 	clear(): T[]
  * }
+ * 
  * interface CloneableStack {
  * 	new <V>(...args: any[]): Stack<V>
  * 	// this static method should remove all function objects from the stack
  * 	clone<T>(original_stack: Stack<T>): Stack<Exclude<T, Function>>
  * }
+ * 
  * const stack_class_alias = class MyStack<T> implements StaticImplements<CloneableStack, typeof MyStack> {
  * 	arr: T[]
  * 	constructor(first_item?: T) {
  * 		this.arr = first_item === undefined ? [] : [first_item]
  * 	}
+ * 
  * 	push(...items: T[]): void { this.arr.push(...items) }
  * 	pop(): T | undefined { return this.arr.pop() }
  * 	clear(): T[] { return this.arr.splice(0) }
+ * 
  * 	static clone<V>(some_stack: Stack<V>) {
  * 		const arr_no_func = (some_stack as MyStack<V>).arr.filter((v) => typeof v !== "function") as Array<Exclude<V, Function>>
  * 		const new_stack = new this<Exclude<V, Function>>()
@@ -125,9 +135,12 @@ export type IncrementNumber = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 /** repeat a string `S` for up to `N = 10` times */
 export type RepeatString<S extends string, N extends number> = N extends 1 ? S : `${S}${RepeatString<S, DecrementNumber[N]>}`
 
-/** create an element-wise intersection between two tuples. <br>
- * note that the intersection `any & T` typically produces `any`,
+/** create an element-wise intersection between two tuples.
+ * 
+ * > [!note]
+ * > the intersection `any & T` typically produces `any`,
  * but when put through this utility type, it will produce `T` for convenience of usage with function parameters intersection.
+ * 
  * @example
  * ```ts
  * type A = TupleIntersect<[number, unknown, string, any], [5, number, string, boolean, 99]>
@@ -157,34 +170,43 @@ export type TupleUnion<
 	UnionKnown<ARR1[N], ARR2[N]> extends (undefined | never) ? [] :
 	[UnionKnown<ARR1[N], ARR2[N]>, ...TupleUnion<ARR1, ARR2, IncrementNumber[N]>] : []
 
-/** perform a union between two types, making sure that if either is `unknown`, then it'll be treated as `never`. <br>
- * why is this useful? because in typescript's `unknown` is a supertype of all types (similar to `any`), which means that something like `T | unknown = unknown`. <br>
+/** perform a union between two types, making sure that if either is `unknown`, then it'll be treated as `never`.
+ * 
+ * why is this useful? because in typescript's `unknown` is a supertype of all types (similar to `any`), which means that something like `T | unknown = unknown`.
  * thus, in a scenario where such a behavior is not desired, you can use this utility type: `UnionKnown<T, unknown> = T`
 */
 export type UnionKnown<A, B> = (unknown extends A ? B : A) | (unknown extends B ? A : B)
 
-/** perform an intersection between two types, making sure that if either is `unknown` or `any`, then it'll be ignored, and only the known type will persevere. <br>
- * why is this useful? because in typescript's `any` is a subtype of all types, which means that something like `T & any = any` (strangely unintuitive). <br>
+/** perform an intersection between two types, making sure that if either is `unknown` or `any`, then it'll be ignored, and only the known type will persevere.
+ * 
+ * why is this useful? because in typescript's `any` is a subtype of all types, which means that something like `T & any = any` (strangely unintuitive).
  * thus, in a scenario where such a behavior is not desired, you can use this utility type: `UnionKnown<T, any> = T`
 */
 export type IntersectKnown<A, B> = (unknown extends A ? B : A) & (unknown extends B ? A : B)
 
-/** array of type `T`, and fixed length `L` <br>
- * technique copied from [stackexchange, user "mstephen19"](https://stackoverflow.com/a/73384647) <br>
- * the `R` generic is for recursion, and not intended for external use.
+/** an array of type `T`, and fixed length `L`.
+ * 
+ * this technique was copied from [stackexchange, user "mstephen19"](https://stackoverflow.com/a/73384647).
+ * 
+ * the generic `R` type parameter is for recursion, and not intended for external use.
 */
 export type ArrayFixedLength<T, L extends number, R extends T[] = []> = R["length"] extends L ? R : ArrayFixedLength<T, L, [...R, T]>
 
-/** represents a scalar mathematical function of `ParamLength` number of input parameters (or variables) <br>
- * for instance, a scalar addition function is merely a mapping from domains $X,Y \in \R$ to $Z \in \R$: $\text{Add} : X \times Y \rightarrow Z$ <br>
+/** represents a scalar mathematical function of `ParamLength` number of input parameters (or variables).
+ * 
+ * for instance, a scalar addition function is merely a mapping from domains:
+ * $X,Y \in \R$ to $Z \in \R$: $\text{Add} : X \times Y \rightarrow Z$ .
+ * 
  * ```ts
  * const add_func: NumericMapFunc<2> = (x, y) => x + y
  * ```
 */
 export type NumericMapFunc<ParamLength extends number> = (...params: ArrayFixedLength<number, ParamLength>) => number
 
-/** represents a higher-order scalar function of `ParamLength` number of array input parameters, which are then manipulated based on index `i`, for all possible `i` <br>
- * @example for instance, to model an array addition function, you would simply do:
+/** represents a higher-order scalar function of `ParamLength` number of array input parameters, which are then manipulated based on index `i`, for all possible `i`.
+ * 
+ * for instance, to model an array addition function, you would simply do:
+ * 
  * ```ts
  * const add_hof: IndexNumericMapFunc<2> = (arrX, arrY) => (i) => arrX[i] + arrY[i]
  * ```
@@ -202,7 +224,8 @@ export type NumericEndianType = "l" | "b"
 /** specify 1-byte, 2-bytes, 4-bytes, or 8-bytes of numeric data*/
 export type DByteSize = "1" | "2" | "4" | "8"
 
-/** indicates the name of a numeric type. <br>
+/** indicates the name of a numeric type.
+ * 
  * the collection of possible valid numeric types is:
  * - `"u1"`, `"u2"`, `"u4"`, `"u8"`, `"i1"`, `"i2"`, `"i4"`, `"i8"`, `"f4"`, `"f8"`, `"u1c"`
  * 
@@ -264,7 +287,8 @@ export type TypedArray<DType extends NumericDType = NumericDType> = {
 /** any numeric array */
 export type NumericArray = TypedArray | Array<number>
 
-/** indicates the name of a numeric type with required endian information, or the use of a variable-sized integer. <br>
+/** indicates the name of a numeric type with required endian information, or the use of a variable-sized integer.
+ * 
  * the collection of possible valid numeric types is:
  * - `"u1"`, `"i1"`, `"u2l"`, `"u2b"`, `"i2l"`, `"i2b"`, `"u4l"`, `"u4b"`, `"u8l"`, `"u8b"`, `"i4l"`, `"i4b"`, `"i8l"`, `"i8b"`, `"f4l"`, `"f4b"`, `"f8l"`, `"f8b"`, `"u1c"`,
  * 

--- a/todo.md
+++ b/todo.md
@@ -1,31 +1,37 @@
 # TODO
 
+## pre-version `0.10.0` todo list
+- [ ] create the "docs/improve-4" branch for fixing the remaining docs and tests in `collections.ts`.
+- [ ] add your "AWS Signature Version 4" computation algorithm to `cryptoman.ts`.
+      for that, you will also have to create aliases for `Crypto.subtle`.
+      but the tradeoff it has is that `Crypto.subtle` is only available in "https" (secure) website contexts, and standalone js runtimes (deno, cloudflare workers, node, bun, etc...)
+- [ ] add `promiseman` submodule that specializes in promise based utility functions.
+- [ ] migrate the following functions and objects to the `timeman`, `alias`, and `promiseman` submodules, as you see fit:
+  - `promiseTimeout`, `debounce`, `debounceAndShare`, `throttle`, `throttleAndTrail`, `THROTTLE_REJECT`, `TIMEOUT`, `ChainedPromiseQueue`.
+- [ ] migrate data uri manipilation/parsing features in the `image` submodule to the `pathman` submodule.
+- [ ] consider migrating `Map` related data-structures inside of `collections.ts` to a new submodule `map.ts` (though I don't like the fact there already exists `mapper.ts`).
+- [ ] consider migrating memorize functions from `lambda.ts` to its own submodule `memorize.ts`.
+- [ ] add the on-the-fly typescript-serving local server task to `/deno.json`, once you have it implemented in `@oazmi/build-tools`.
+
 ## pre-version `0.9.0` todo list
 
 - [x] create the "docs/improve-1" branch for changes related to documentation and minification repair of `builtin_aliases_deps.ts`.
 - [x] create the "docs/improve-2" branch for major improvements related to documentation repair/upgrade.
-- [ ] create the "docs/improve-3" branch for all changes related to documentation repair/upgrade.
+- [x] create the "docs/improve-3" branch for all changes related to documentation repair/upgrade.
 - [x] rename the following submodules (and also take care of potential doc link breakdown when using `!module_name`):
   - [x] ~~`builtin_aliases` -> `aliases`~~
     - [x] ended up deleting this submodule
   - [x] `builtin_aliases_deps` -> `alias`
   - [x] `crypto` -> `cryptoman` ? unsure about this one
   - [x] `path` -> `pathman`
-- [ ] fix the doc examples so that they do not error when `deno test --doc "./src/"` is ran.
-- [ ] populate the doc examples with legitimate test cases using `"jsr:@std/assert"` for assertion.
-- [ ] fix the `slice` and `splice` (and maybe there are other methods as well) method issue with your custom subclasses of `Array`, `Map`, and `Set`,
+- [x] fix the doc examples so that they do not error when `deno test --doc "./src/"` is ran.
+- [x] populate the doc examples with legitimate test cases using `"jsr:@std/assert"` for assertion.
+- [x] fix the `slice` and `splice` (and maybe there are other methods as well) method issue with your custom subclasses of `Array`, `Map`, and `Set`,
       which result in the creation of a new subclass when these methods are called, instead of creating a classic `Array`, `Map`, or `Set`.
   - ~~potential solution involves the creation of a utility function that does `slice` and `splice` on `Array` subclasses without invoking their `slice` or `splice` methods.~~
   - the correct solution involves setting the subclass's `Symbol.species` property to the base built-in type (`Array`, `Map`, etc...), so that the methods that create clones of the subclass create the equivalent base built-in type, instead of a new instance of our subclass.
-- [ ] add your "AWS Signature Version 4" computation algorithm to `cryptoman.ts`.
-      for that, you will also have to create aliases for `Crypto.subtle`.
-      but the tradeoff it has is that `Crypto.subtle` is only available in "https" (secure) website contexts, and standalone js runtimes (deno, cloudflare workers, node, bun, etc...)
-- [ ] add `promiseman` submodule that specializes in promise based utility functions.
-- [ ] migrate the following functions and objects to the `timeman`, `aliases_deps`, and `promiseman` submodules, as you see fit:
-  - `promiseTimeout`, `debounce`, `debounceAndShare`, `throttle`, `throttleAndTrail`, `THROTTLE_REJECT`, `TIMEOUT`
-- [ ] migrate data uri manipilation/parsing features in the `image` submodule to the `pathman` submodule.
 - [x] put your DIY deno mascot somewhere in the repo's readme, and make sure that the svg is uploaded to jsr and npm
-- [ ] IDEA: make "megaman robot master" like ascii-art mascots for each of your submodule ending with a "man" (i.e. "cryptoman", "pathman", "stringman", etc...), and put them in your module-level comment.
+- [ ] DUMB IDEA: make "megaman robot master" like ascii-art mascots for each of your submodule ending with a "man" (i.e. "cryptoman", "pathman", "stringman", etc...), and put them in your module-level comment.
 - [x] in "pathman.ts", rename references to "unix" and "unix-style" with "posix". can't believe you swapped posix for unix _facepalm_.
 - [x] in "pathman.ts", make all doc tests more readable by using single letter directory names.
 - [x] in "binder.ts", give a doc comment to each exported binding function, just so that it'll raise your jsr score.
@@ -51,4 +57,3 @@
 - [x] erase the todo list from `/src/deps.ts`
 - [x] in `pathman`, make `uri_protocol_and_scheme_mapping` exportable, so that the end user may add additional uri schemes of their liking.
 - [x] add a description to each `task` in `/deno.json`.
-- [ ] add the on-the-fly typescript-serving local server task to `/deno.json`, once you have it implemented in `@oazmi/build-tools`.

--- a/todo.md
+++ b/todo.md
@@ -15,7 +15,8 @@
 - [ ] populate the doc examples with legitimate test cases using `"jsr:@std/assert"` for assertion.
 - [ ] fix the `slice` and `splice` (and maybe there are other methods as well) method issue with your custom subclasses of `Array`, `Map`, and `Set`,
       which result in the creation of a new subclass when these methods are called, instead of creating a classic `Array`, `Map`, or `Set`.
-      potential solution involves the creation of a utility function that does `slice` and `splice` on `Array` subclasses without invoking their `slice` or `splice` methods.
+  - ~~potential solution involves the creation of a utility function that does `slice` and `splice` on `Array` subclasses without invoking their `slice` or `splice` methods.~~
+  - the correct solution involves setting the subclass's `Symbol.species` property to the base built-in type (`Array`, `Map`, etc...), so that the methods that create clones of the subclass create the equivalent base built-in type, instead of a new instance of our subclass.
 - [ ] add your "AWS Signature Version 4" computation algorithm to `cryptoman.ts`.
       for that, you will also have to create aliases for `Crypto.subtle`.
       but the tradeoff it has is that `Crypto.subtle` is only available in "https" (secure) website contexts, and standalone js runtimes (deno, cloudflare workers, node, bun, etc...)


### PR DESCRIPTION
We're close to overtaking Nintendo 3DS in terms of stability!

## changes

- migrate `Array` related functions to the added submodule `/src/array1d.ts`.
- make the classes in `/src/collections.ts` that inherit from `Array` have their `[Symbol.species]` set to `Array`, so that they create a vanilla `Array` instead of a subclass thereof, when array creation methods are used, such as `splice` and `map`.
- improve existing documentation comments.
- add examples and test code to more functions.

## breaking changes

the following changes were made to `/src/collections.ts`:
- classes that extend `Array` have their `[Symbol.species]` set to `Array`.
- narrowed down the the constructor signature for `List`.
- revamp `Deque` and its methods.

the following exports were migrated:
- `shuffleArray` and `shuffleDeque` were moved from `/src/array2d.ts` to `/src/array1d.ts`.
- `resolveRange` was moved from `/src/typedbuffer.ts` to `/src/array1d.ts`.
